### PR TITLE
index: use references to a combined tag list

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ This file lists notable changes that have been made to the application on each
 release. Releases are tracked and referred to using git tags.
 
 
+## Upcoming changes for next version
+- Improvements:
+  - The size of the gallery `index.json` file has been reduced.
+
+
 ## v2.1 - 2022-09-04
 - New features:
   - Add support for Markdown-formatted files, which are now rendered.

--- a/compiler/src/Config.hs
+++ b/compiler/src/Config.hs
@@ -1,7 +1,7 @@
 -- ldgallery - A static generator which turns a collection of tagged
 --             pictures into a searchable web gallery.
 --
--- Copyright (C) 2019-2020  Pacien TRAN-GIRARD
+-- Copyright (C) 2019-2022  Pacien TRAN-GIRARD
 --
 -- This program is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as
@@ -28,8 +28,7 @@ import GHC.Generics (Generic)
 import Data.Aeson (ToJSON, FromJSON, withObject, (.:?), (.!=))
 import qualified Data.Aeson as JSON
 
-import Files (FileName)
-import Input (decodeYamlFile)
+import Files (FileName, decodeYamlFile)
 
 
 data Resolution = Resolution

--- a/compiler/src/Input.hs
+++ b/compiler/src/Input.hs
@@ -1,7 +1,7 @@
 -- ldgallery - A static generator which turns a collection of tagged
 --             pictures into a searchable web gallery.
 --
--- Copyright (C) 2019-2021  Pacien TRAN-GIRARD
+-- Copyright (C) 2019-2022  Pacien TRAN-GIRARD
 --
 -- This program is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as
@@ -17,15 +17,13 @@
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 module Input
-  ( decodeYamlFile
-  , Sidecar(..)
+  ( Sidecar(..)
   , InputTree(..), readInputTree, filterInputTree
   ) where
 
 
 import GHC.Generics (Generic)
-import Control.Exception (Exception, AssertionFailed(..), throw, throwIO)
-import Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Exception (AssertionFailed(..), throw)
 import Data.Function ((&))
 import Data.Functor ((<&>))
 import Data.Maybe (catMaybes, fromMaybe)
@@ -33,22 +31,12 @@ import Data.Bool (bool)
 import Data.List (find, isSuffixOf)
 import Data.Time.Clock (UTCTime)
 import Data.Time.LocalTime (ZonedTime)
-import Data.Yaml (ParseException, decodeFileEither)
 import Data.Aeson (FromJSON)
 import qualified Data.Map.Strict as Map
 import System.FilePath (isExtensionOf, dropExtension)
 import System.Directory (doesFileExist, getModificationTime)
 
 import Files
-
-
-data LoadException = LoadException String ParseException deriving Show
-instance Exception LoadException
-
-decodeYamlFile :: (MonadIO m, FromJSON a) => FileName -> m a
-decodeYamlFile path =
-  liftIO $ Data.Yaml.decodeFileEither path
-  >>= either (throwIO . LoadException path) return
 
 
 -- | Tree representing the input from the input directory.

--- a/viewer/src/@types/gallery.ts
+++ b/viewer/src/@types/gallery.ts
@@ -2,6 +2,7 @@
 --             pictures into a searchable web gallery.
 --
 -- Copyright (C) 2019-2022  Guillaume FOUET
+--               2022       Pacien TRAN-GIRARD
 --
 -- This program is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as
@@ -41,6 +42,7 @@ export interface Thumbnail {
   resolution: Resolution;
 }
 export type RawTag = string;
+export type TagId = number;
 
 // ---
 
@@ -82,7 +84,13 @@ export interface Item {
   title: string;
   datetime: string;
   description: string;
-  tags: RawTag[];
+  tags: TagId[];
+
+  /**
+   * @deprecated Use tags (TagId) instead. This is a legacy adapter.
+   */
+  stringTags: RawTag[];
+
   path: string;
   thumbnail?: Thumbnail;
   properties:
@@ -125,5 +133,6 @@ export interface IndexProperties {
 }
 export interface Index {
   properties: IndexProperties;
+  tags: RawTag[];
   tree: DirectoryItem;
 }

--- a/viewer/src/@types/gallery.ts
+++ b/viewer/src/@types/gallery.ts
@@ -85,12 +85,6 @@ export interface Item {
   datetime: string;
   description: string;
   tags: TagId[];
-
-  /**
-   * @deprecated Use tags (TagId) instead. This is a legacy adapter.
-   */
-  stringTags: RawTag[];
-
   path: string;
   thumbnail?: Thumbnail;
   properties:

--- a/viewer/src/services/indexFactory.ts
+++ b/viewer/src/services/indexFactory.ts
@@ -117,7 +117,7 @@ function _isDiscriminantTagOnly(tags: RawTag[], node: TagNode): boolean {
 // ---
 
 export const useIndexFactory = () => {
-  function generateTags(root: Item | null, tagArray?: RawTag[]): TagIndex {
+  function generateTags(root?: Item, tagArray?: RawTag[]): TagIndex {
     const tagsIndex: TagIndex = {};
     if (!tagArray) return tagsIndex;
     if (root) _pushTagsForItem(tagArray, tagsIndex, root);

--- a/viewer/src/services/indexFactory.ts
+++ b/viewer/src/services/indexFactory.ts
@@ -43,12 +43,13 @@ function _pushPartToIndex(index: TagNode, part: string, item: Item, rootPart: bo
 }
 
 // Pushes all tags for a root item (and its children) to the index
-function _pushTagsForItem(tagsIndex: TagIndex, item: Item): void {
+function _pushTagsForItem(tagArray: RawTag[], tagsIndex: TagIndex, item: Item): void {
   if (isDirectory(item)) {
-    item.properties.items.forEach(item => _pushTagsForItem(tagsIndex, item));
+    item.properties.items.forEach(item => _pushTagsForItem(tagArray, tagsIndex, item));
     return; // Directories are not indexed
   }
-  for (const tag of item.stringTags) {
+  for (const tagId of item.tags) {
+    const tag = tagArray[tagId];
     const parts = tag.split(':');
     let lastPart: string | null = null;
     for (const part of parts) {
@@ -116,9 +117,10 @@ function _isDiscriminantTagOnly(tags: RawTag[], node: TagNode): boolean {
 // ---
 
 export const useIndexFactory = () => {
-  function generateTags(root: Item | null): TagIndex {
+  function generateTags(root: Item | null, tagArray?: RawTag[]): TagIndex {
     const tagsIndex: TagIndex = {};
-    if (root) _pushTagsForItem(tagsIndex, root);
+    if (!tagArray) return tagsIndex;
+    if (root) _pushTagsForItem(tagArray, tagsIndex, root);
     return tagsIndex;
   }
 

--- a/viewer/src/services/indexFactory.ts
+++ b/viewer/src/services/indexFactory.ts
@@ -48,7 +48,7 @@ function _pushTagsForItem(tagsIndex: TagIndex, item: Item): void {
     item.properties.items.forEach(item => _pushTagsForItem(tagsIndex, item));
     return; // Directories are not indexed
   }
-  for (const tag of item.tags) {
+  for (const tag of item.stringTags) {
     const parts = tag.split(':');
     let lastPart: string | null = null;
     for (const part of parts) {

--- a/viewer/src/store/galleryStore.ts
+++ b/viewer/src/store/galleryStore.ts
@@ -109,7 +109,7 @@ export const useGalleryStore = defineStore('gallery', {
     // Indexes the gallery
     async indexTags() {
       const root = this.galleryIndex?.tree ?? null;
-      const index = indexFactory.generateTags(root);
+      const index = indexFactory.generateTags(root, this.galleryIndex?.tags);
       this.tagsIndex = index;
       return index;
     },

--- a/viewer/src/store/galleryStore.ts
+++ b/viewer/src/store/galleryStore.ts
@@ -18,11 +18,10 @@
 -- along with this program.  If not, see <https://www.gnu.org/licenses/>.
 */
 
-import { Config, Index, Item, RawTag } from '@/@types/gallery';
+import { Config, Index, Item } from '@/@types/gallery';
 import { TagCategory, TagIndex, TagSearch } from '@/@types/tag';
 import { useIndexFactory } from '@/services/indexFactory';
 import { useNavigation } from '@/services/navigation';
-import { isDirectory } from '@/services/itemGuards';
 import { defineStore } from 'pinia';
 
 const navigation = useNavigation();
@@ -37,27 +36,6 @@ function getUrlConfig() {
 function responseToJson(response: Response) {
   if (!response.ok) throw new Error(`${response.status}: ${response.statusText}`);
   return response.json();
-}
-
-/// @deprecated Adapter adding a tag string getter to gallery items.
-function patchItemStringTagsAdapter(tagArray: RawTag[], item: Item): Item {
-  Object.defineProperty(item, 'stringTags', {
-    get() { return item.tags.map(tagId => tagArray[tagId]); },
-  });
-
-  if (isDirectory(item)) {
-    for (const child of item.properties.items) {
-      patchItemStringTagsAdapter(tagArray, child);
-    }
-  }
-
-  return item;
-}
-
-/// @deprecated Adapter adding a tag string getter to all gallery items.
-function patchIndexStringTagsAdapter(index: Index): Index {
-  patchItemStringTagsAdapter(index.tags, index.tree);
-  return index;
 }
 
 export const useGalleryStore = defineStore('gallery', {
@@ -100,7 +78,6 @@ export const useGalleryStore = defineStore('gallery', {
       const index = this.config?.galleryIndex ?? 'index.json';
       await fetch(`${process.env.VUE_APP_DATA_URL}${root}${index}`, { cache: 'no-cache' })
         .then(responseToJson)
-        .then(patchIndexStringTagsAdapter)
         .then(v => (this.galleryIndex = v))
         .then(this.indexTags)
         .then(this.indexTagCategories);

--- a/viewer/src/store/galleryStore.ts
+++ b/viewer/src/store/galleryStore.ts
@@ -85,22 +85,16 @@ export const useGalleryStore = defineStore('gallery', {
     },
     // Indexes the gallery
     async indexTags() {
-      const root = this.galleryIndex?.tree ?? null;
-      const index = indexFactory.generateTags(root, this.galleryIndex?.tags);
-      this.tagsIndex = index;
-      return index;
+      const { tree, tags } = this.galleryIndex ?? {};
+      return (this.tagsIndex = indexFactory.generateTags(tree, tags));
     },
     // Indexes the proposed categories
     async indexTagCategories() {
-      const categories = indexFactory.generateCategories(this.tagsIndex, this.galleryIndex?.properties.tagCategories);
-      this.tagsCategories = categories;
-      return categories;
+      return (this.tagsCategories = indexFactory.generateCategories(this.tagsIndex, this.galleryIndex?.properties.tagCategories));
     },
     // Searches for tags
     async search(filters: string[]) {
-      const results = filters.flatMap(filter => indexFactory.searchTags(this.tagsIndex, filter, true));
-      this.currentSearch = results;
-      return results;
+      return (this.currentSearch = filters.flatMap(filter => indexFactory.searchTags(this.tagsIndex, filter, true)));
     },
   },
 });

--- a/viewer/src/views/layout/left/LayoutLeft.vue
+++ b/viewer/src/views/layout/left/LayoutLeft.vue
@@ -120,7 +120,7 @@ function serializeSearch() {
   return query;
 }
 
-const currentTags = computed(() => galleryStore.currentItem?.tags ?? []);
+const currentTags = computed(() => galleryStore.currentItem?.stringTags ?? []);
 
 watch(() => route.query, (query) => {
   const filters = Object.keys(query);

--- a/viewer/src/views/layout/left/LayoutLeft.vue
+++ b/viewer/src/views/layout/left/LayoutLeft.vue
@@ -120,7 +120,9 @@ function serializeSearch() {
   return query;
 }
 
-const currentTags = computed(() => galleryStore.currentItem?.stringTags ?? []);
+const currentTags = computed(() =>
+  (galleryStore.currentItem?.tags ?? [])
+    .map(tag => galleryStore.galleryIndex?.tags[tag]));
 
 watch(() => route.query, (query) => {
   const filters = Object.keys(query);

--- a/viewer/src/views/layout/left/LayoutProposition.vue
+++ b/viewer/src/views/layout/left/LayoutProposition.vue
@@ -118,7 +118,7 @@ const propositions = computed<Record<string, number>>(() => {
   if (searchFilters.length > 0) {
     // Tags count from current search
     extractDistinctItems(searchFilters)
-      .flatMap(item => item.tags)
+      .flatMap(item => item.stringTags)
       .map(rightmost)
       .filter(rawTag => props.tagsIndex[rawTag] && !searchFilters.find(search => search.tag === rawTag))
       .forEach(rawTag => (propositions[rawTag] = (propositions[rawTag] ?? 0) + 1));

--- a/viewer/src/views/layout/left/LayoutProposition.vue
+++ b/viewer/src/views/layout/left/LayoutProposition.vue
@@ -118,7 +118,8 @@ const propositions = computed<Record<string, number>>(() => {
   if (searchFilters.length > 0) {
     // Tags count from current search
     extractDistinctItems(searchFilters)
-      .flatMap(item => item.stringTags)
+      .flatMap(item => item.tags)
+      .flatMap(tag => galleryStore.galleryIndex?.tags[tag])
       .map(rightmost)
       .filter(rawTag => props.tagsIndex[rawTag] && !searchFilters.find(search => search.tag === rawTag))
       .forEach(rawTag => (propositions[rawTag] = (propositions[rawTag] ?? 0) + 1));


### PR DESCRIPTION
- compiler: move decodeYamlFile util from Input to Files
- compiler/index: aggregate tags in list and use index references
- viewer: add adapter for int tag references
- viewer: remove some deprecated stringTags adapter uses
