### PR TITLE
viewer: CTRL+K to focus in search field

### DIFF
--- a/viewer/ldgallery-viewer.7.md
+++ b/viewer/ldgallery-viewer.7.md
@@ -2,7 +2,7 @@
 pagetitle: Viewer user manual - ldgallery
 title: LDGALLERY-VIEWER(7) ldgallery
 author: Pacien TRAN-GIRARD, Guillaume FOUET
-date: 2022-09-04 (v2.1)
+date: 2022-10-26 (v2.1-SNAPSHOT)
 ---
 
 
@@ -41,6 +41,13 @@ Items of the following formats can be opened and visualised within the web appli
 * PDFs
 
 Formats which are not listed above or which are not supported by the user's web browser are offered for download instead of being directly displayed in the same window.
+
+
+# KEYBOARD SHORTCUTS
+
+`CTRL-K`
+: Moves the focus to the tag search field, opening the side search panel if it is closed.
+  Pressing again while in the search input field sets the focus to the browser's address bar.
 
 
 # SEARCH QUERIES

--- a/viewer/src/views/layout/left/LayoutTagInput.vue
+++ b/viewer/src/views/layout/left/LayoutTagInput.vue
@@ -23,7 +23,7 @@
     v-model="search"
     :placeholder="t('tagInput.placeholder')"
     :tabindex="50"
-    @focus="e => (e.target as HTMLInputElement).select()"
+    @focus="(e: FocusEvent) => (e.target as HTMLInputElement).select()"
     @keypress.enter="inputEnter"
     @keydown.backspace="inputBackspace"
   />
@@ -58,7 +58,8 @@ import LdDropdown from '@/components/LdDropdown.vue';
 import LdInput from '@/components/LdInput.vue';
 import { useIndexFactory } from '@/services/indexFactory';
 import { useGalleryStore } from '@/store/galleryStore';
-import { computedEager, useElementBounding, useFocus, useVModel } from '@vueuse/core';
+import { useUiStore } from '@/store/uiStore';
+import { computedEager, onKeyStroke, useElementBounding, useFocus, useKeyModifier, useVModel } from '@vueuse/core';
 import { computed, ref, StyleValue, watchEffect } from 'vue';
 import { useI18n } from 'vue-i18n';
 
@@ -69,6 +70,7 @@ const emit = defineEmits(['update:modelValue', 'search', 'opening', 'closing']);
 const model = useVModel(props, 'modelValue', emit);
 
 const { t } = useI18n();
+const uiStore = useUiStore();
 const galeryStore = useGalleryStore();
 const indexFactory = useIndexFactory();
 
@@ -85,6 +87,16 @@ const dropdownStyle = computedEager<StyleValue>(() => ({ height: `calc(100vh - 8
 
 const input = ref();
 const { focused } = useFocus(input);
+
+// ---
+
+const controlState = useKeyModifier('Control');
+onKeyStroke('k', e => {
+  if (!controlState.value || focused.value) return;
+  e.preventDefault();
+  uiStore.toggleFullWidth(false);
+  focused.value = true;
+});
 
 // ---
 


### PR DESCRIPTION
github: closes #328

Note: 
Ctrl+k will focus the TagInput the first time.
If hit another time, it will regress to the browser's default behavior (focusing the address bar on Chrome).