### PR TITLE
flake: add example as a package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -117,6 +117,19 @@
         ];
       };
 
+      example = pkgs.stdenv.mkDerivation {
+        pname = "ldgallery-example";
+        version = ldgalleryVersion;
+        src = ./example;
+        nativeBuildInputs = [ ldgallery ];
+        buildPhase = ''
+          # Need UTF-8: https://github.com/ldgallery/ldgallery/issues/341
+          export LC_ALL=C.UTF-8
+          ldgallery --input-dir src --output-dir $out --with-viewer
+        '';
+        installPhase = ":";
+      };
+
       default = ldgallery;
     };
 


### PR DESCRIPTION
This allows quickly testing compiling the example gallery with a given
version of ldgallery. For example:

```sh
nix build github:ldgallery/ldgallery?rev=commithash#example -o result
python -m http.server --directory result
```
