### PR TITLE
Revert "compiler: fix support for non-utf8 terminals"

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,7 +11,6 @@ release. Releases are tracked and referred to using git tags.
 - Bug fixes:
   - compiler: fix detection of dimensions of EXIF-rotated pictures.
     Rebuild the gallery with `--rebuild-all` to purge erroneous cached data.
-  - compiler: fix support for non-UTF8 terminals.
   - viewer: fix theme quirks (line spacing, icon colours).
   - viewer: fix ghost keyboard hints when the search panel is closed.
 

--- a/compiler/app/Main.hs
+++ b/compiler/app/Main.hs
@@ -1,7 +1,7 @@
 -- ldgallery - A static generator which turns a collection of tagged
 --             pictures into a searchable web gallery.
 --
--- Copyright (C) 2019-2022  Pacien TRAN-GIRARD
+-- Copyright (C) 2019-2021  Pacien TRAN-GIRARD
 --
 -- This program is free software: you can redistribute it and/or modify
 -- it under the terms of the GNU Affero General Public License as
@@ -28,7 +28,6 @@ import Data.Aeson (ToJSON)
 import System.FilePath ((</>))
 import System.Directory (canonicalizePath, listDirectory)
 import System.Console.CmdArgs
-import Main.Utf8 (withUtf8)
 
 import Compiler
 import Files (readDirectory, copyTo, remove)
@@ -104,7 +103,7 @@ options = Options
 
 main :: IO ()
 main =
-  withUtf8 $ do
+  do
     opts <- cmdArgs options
     buildGallery opts
     deployViewer opts

--- a/compiler/package.yaml
+++ b/compiler/package.yaml
@@ -4,7 +4,7 @@ homepage:            https://ldgallery.pacien.org
 github:              "pacien/ldgallery"
 license:             AGPL-3.0-only
 author:              "Pacien TRAN-GIRARD, Guillaume FOUET"
-copyright:           "2019-2022 Pacien TRAN-GIRARD, Guillaume FOUET"
+copyright:           "2019-2021 Pacien TRAN-GIRARD, Guillaume FOUET"
 
 extra-source-files:
 - readme.md
@@ -29,7 +29,6 @@ dependencies:
 - safe
 - time
 - process
-- with-utf8
 
 default-extensions:
 - DuplicateRecordFields

--- a/flake.nix
+++ b/flake.nix
@@ -137,6 +137,8 @@
         src = ./example;
         nativeBuildInputs = [ ldgallery ];
         buildPhase = ''
+          # Need UTF-8: https://github.com/ldgallery/ldgallery/issues/341
+          export LC_ALL=C.UTF-8
           ldgallery --input-dir src --output-dir $out --with-viewer
         '';
         installPhase = ":";


### PR DESCRIPTION
The reverted changeset fixed some crash due to character encoding
mismatch in terminal emulators.

Doing so, it made it possible for the compiler to complete without
reporting any error, while outputting wrongly encoded files.

It's better to revert that changeset until all the encoding issue are
solved consistently.

This reverts commit 0fddc74a3f9add47841124b4d77b097f4646d14f.
