### PR TITLE
viewer: use nodejs 16 -> 18 for build in flake and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           # Latest version officially tested for Ld
-          node-version: 16.14.2
+          node-version: 18.16.0
       - name: Lint and build Node.js Vue project
         working-directory: viewer
         run: |

--- a/flake.nix
+++ b/flake.nix
@@ -35,7 +35,7 @@
       tmux
 
       # viewer
-      nodejs-16_x
+      nodejs-18_x
       yarn
 
       # compiler


### PR DESCRIPTION
Node v16 is reaching EOL in a few months.
Build seems to work fine with the new LTS (v18).
